### PR TITLE
feat: use statePath for inferred @DataAction() type

### DIFF
--- a/integration/tests/common-extensions/deep-data-action-type.spec.ts
+++ b/integration/tests/common-extensions/deep-data-action-type.spec.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NgxsDataPluginModule } from '@ngxs-labs/data';
+import { DataAction, Payload, StateRepository } from '@ngxs-labs/data/decorators';
+import { NgxsDataRepository } from '@ngxs-labs/data/repositories';
+import { Actions, NgxsModule, State } from '@ngxs/store';
+import { take } from 'rxjs/operators';
+
+describe('[TEST]: Deep data action type', () => {
+    it('should use deeply nested @DataAction() names', fakeAsync(() => {
+        @StateRepository()
+        @State({ name: 'c', defaults: { prop: undefined } })
+        @Injectable()
+        class C extends NgxsDataRepository<{ prop: string }> {
+            @DataAction()
+            public setProp(@Payload('prop') prop: string) {
+                this.ctx.setState({ prop });
+            }
+        }
+
+        @StateRepository()
+        @State({ name: 'b', defaults: { prop: undefined }, children: [C] })
+        @Injectable()
+        class B extends NgxsDataRepository<{ prop: string }> {
+            @DataAction()
+            public setProp(@Payload('prop') prop: string) {
+                this.ctx.setState({ prop });
+            }
+        }
+
+        @StateRepository()
+        @State({ name: 'a', defaults: { prop: undefined }, children: [B] })
+        @Injectable()
+        class A extends NgxsDataRepository<{ prop: string }> {
+            @DataAction()
+            public setProp(@Payload('prop') prop: string) {
+                this.ctx.setState({ prop });
+            }
+        }
+
+        TestBed.configureTestingModule({
+            imports: [NgxsModule.forRoot([A, B, C]), NgxsDataPluginModule.forRoot()]
+        });
+
+        const stateA: A = TestBed.get(A);
+        expect(stateA.getState()).toEqual({
+            prop: undefined,
+            b: {
+                prop: undefined,
+                c: { prop: undefined },
+            },
+        });
+
+        const stateB: B = TestBed.get(B);
+        expect(stateB.getState()).toEqual({
+            prop: undefined,
+            c: { prop: undefined },
+        });
+
+        const stateC: C = TestBed.get(C);
+        expect(stateC.getState()).toEqual({
+            prop: undefined,
+        });
+
+        const actions: any[] = [];
+        const actions$: Actions = TestBed.get(Actions);
+        actions$
+            .pipe(take(6))
+            .subscribe(action => actions.push(action));
+
+        stateA.setProp('A');
+        stateB.setProp('B');
+        stateC.setProp('C');
+
+        tick(100);
+
+        expect(actions[0].action.constructor.type).toEqual('@a.setProp(prop)');
+        expect(actions[2].action.constructor.type).toEqual('@a/b.setProp(prop)');
+        expect(actions[4].action.constructor.type).toEqual('@a/b/c.setProp(prop)');
+
+        expect(stateA.snapshot).toEqual({
+            prop: 'A',
+            b: {
+                prop: 'B',
+                c: { prop: 'C' },
+            },
+        });
+    }));
+
+    afterEach(() => {
+        TestBed.resetTestingModule();
+    });
+});

--- a/integration/tests/common-extensions/name-creator.spec.ts
+++ b/integration/tests/common-extensions/name-creator.spec.ts
@@ -2,10 +2,17 @@ import { actionNameCreator, MethodArgsRegistry } from '@ngxs-labs/data/internals
 
 describe('[TEST]: actionNameCreator', () => {
     it('should be correct', () => {
-        expect(actionNameCreator({ stateName: 'A', methodName: 'a', argumentsNames: [] })).toEqual('@A.a()');
+        expect(actionNameCreator({ statePath: 'A', methodName: 'a', argumentsNames: [] })).toEqual('@A.a()');
 
-        expect(actionNameCreator({ stateName: 'A', methodName: 'a', argumentsNames: ['x', 'y', 'z'] })).toEqual(
+        expect(actionNameCreator({ statePath: 'A', methodName: 'a', argumentsNames: ['x', 'y', 'z'] })).toEqual(
             '@A.a($arg0, $arg1, $arg2)'
+        );
+    });
+    
+    it('should be correct create nested statePath', () => {
+        expect(actionNameCreator({ statePath: 'A.B.C', methodName: 'a', argumentsNames: [] })).toEqual('@A/B/C.a()');
+        expect(actionNameCreator({ statePath: 'A.B', methodName: 'a', argumentsNames: ['x', 'y', 'z'] })).toEqual(
+            '@A/B.a($arg0, $arg1, $arg2)'
         );
     });
 
@@ -16,7 +23,7 @@ describe('[TEST]: actionNameCreator', () => {
 
         expect(
             actionNameCreator({
-                stateName: 'A',
+                statePath: 'A',
                 methodName: 'a',
                 argumentsNames: ['x', 'y', 'z'],
                 argumentRegistry: registry
@@ -32,7 +39,7 @@ describe('[TEST]: actionNameCreator', () => {
 
         expect(
             actionNameCreator({
-                stateName: 'A',
+                statePath: 'A',
                 methodName: 'a',
                 argumentsNames: ['x', 'y', 'z'],
                 argumentRegistry: registry

--- a/lib/decorators/src/data-action/data-action.ts
+++ b/lib/decorators/src/data-action/data-action.ts
@@ -1,5 +1,25 @@
-import { $args, actionNameCreator, combineStream, getMethodArgsRegistry, MethodArgsRegistry, NgxsDataFactory, NgxsDataInjector, validateAction } from '@ngxs-labs/data/internals';
-import { ActionEvent, Any, DataStateClass, Descriptor, DispatchedResult, ImmutableDataRepository, NgxsDataOperation, NgxsRepositoryMeta, PlainObjectOf, RepositoryActionOptions } from '@ngxs-labs/data/typings';
+import {
+  $args,
+  actionNameCreator,
+  combineStream,
+  getMethodArgsRegistry,
+  MethodArgsRegistry,
+  NgxsDataFactory,
+  NgxsDataInjector,
+  validateAction
+} from '@ngxs-labs/data/internals';
+import {
+  ActionEvent,
+  Any,
+  DataStateClass,
+  Descriptor,
+  DispatchedResult,
+  ImmutableDataRepository,
+  NgxsDataOperation,
+  NgxsRepositoryMeta,
+  PlainObjectOf,
+  RepositoryActionOptions
+} from '@ngxs-labs/data/typings';
 import { MappedStore, MetaDataModel } from '@ngxs/store/src/internal/internals';
 import { isObservable, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';

--- a/lib/decorators/src/data-action/data-action.ts
+++ b/lib/decorators/src/data-action/data-action.ts
@@ -1,30 +1,30 @@
 import {
-  $args,
-  actionNameCreator,
-  combineStream,
-  getMethodArgsRegistry,
-  MethodArgsRegistry,
-  NgxsDataFactory,
-  NgxsDataInjector,
-  validateAction
+    $args,
+    actionNameCreator,
+    combineStream,
+    getMethodArgsRegistry,
+    MethodArgsRegistry,
+    NgxsDataFactory,
+    NgxsDataInjector,
+    validateAction
 } from '@ngxs-labs/data/internals';
 import {
-  ActionEvent,
-  Any,
-  DataStateClass,
-  Descriptor,
-  DispatchedResult,
-  ImmutableDataRepository,
-  NgxsDataOperation,
-  NgxsRepositoryMeta,
-  PlainObjectOf,
-  RepositoryActionOptions
+    ActionEvent,
+    Any,
+    DataStateClass,
+    Descriptor,
+    DispatchedResult,
+    ImmutableDataRepository,
+    NgxsDataOperation,
+    NgxsRepositoryMeta,
+    PlainObjectOf,
+    RepositoryActionOptions
 } from '@ngxs-labs/data/typings';
 import { MappedStore, MetaDataModel } from '@ngxs/store/src/internal/internals';
 import { isObservable, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { REPOSITORY_ACTION_OPTIONS } from './data-action.config';
 
+import { REPOSITORY_ACTION_OPTIONS } from './data-action.config';
 
 // eslint-disable-next-line max-lines-per-function
 export function DataAction(options: RepositoryActionOptions = REPOSITORY_ACTION_OPTIONS): MethodDecorator {

--- a/lib/decorators/src/data-action/data-action.ts
+++ b/lib/decorators/src/data-action/data-action.ts
@@ -1,30 +1,10 @@
-import {
-    $args,
-    actionNameCreator,
-    combineStream,
-    getMethodArgsRegistry,
-    MethodArgsRegistry,
-    NgxsDataFactory,
-    NgxsDataInjector,
-    validateAction
-} from '@ngxs-labs/data/internals';
-import {
-    ActionEvent,
-    Any,
-    DataStateClass,
-    Descriptor,
-    DispatchedResult,
-    ImmutableDataRepository,
-    NgxsDataOperation,
-    NgxsRepositoryMeta,
-    PlainObjectOf,
-    RepositoryActionOptions
-} from '@ngxs-labs/data/typings';
+import { $args, actionNameCreator, combineStream, getMethodArgsRegistry, MethodArgsRegistry, NgxsDataFactory, NgxsDataInjector, validateAction } from '@ngxs-labs/data/internals';
+import { ActionEvent, Any, DataStateClass, Descriptor, DispatchedResult, ImmutableDataRepository, NgxsDataOperation, NgxsRepositoryMeta, PlainObjectOf, RepositoryActionOptions } from '@ngxs-labs/data/typings';
 import { MappedStore, MetaDataModel } from '@ngxs/store/src/internal/internals';
 import { isObservable, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import { REPOSITORY_ACTION_OPTIONS } from './data-action.config';
+
 
 // eslint-disable-next-line max-lines-per-function
 export function DataAction(options: RepositoryActionOptions = REPOSITORY_ACTION_OPTIONS): MethodDecorator {
@@ -49,9 +29,8 @@ export function DataAction(options: RepositoryActionOptions = REPOSITORY_ACTION_
             if (!operation) {
                 // Note: late init operation when first invoke action method
                 const argumentsNames: string[] = $args(originalMethod);
-                const stateName: string = stateMeta.name!;
                 const type: string = actionNameCreator({
-                    stateName,
+                    statePath: stateMeta.path!,
                     methodName: key,
                     argumentsNames,
                     argumentRegistry: registry

--- a/lib/internals/src/utils/action/action-name-creator.ts
+++ b/lib/internals/src/utils/action/action-name-creator.ts
@@ -25,5 +25,5 @@ export function actionNameCreator(options: ActionNameCreatorOptions): string {
         }
     }
 
-    return `@${statePath.split('.').join('/')}.${methodName}(${argsList})`;
+    return `@${statePath.replace(/\./g, '/')}.${methodName}(${argsList})`;
 }

--- a/lib/internals/src/utils/action/action-name-creator.ts
+++ b/lib/internals/src/utils/action/action-name-creator.ts
@@ -1,14 +1,14 @@
 import { MethodArgsRegistry } from '../method-args-registry/method-args-registry';
 
 interface ActionNameCreatorOptions {
-    stateName: string | null;
+    statePath: string;
     methodName: string;
     argumentsNames: string[];
     argumentRegistry?: MethodArgsRegistry;
 }
 
 export function actionNameCreator(options: ActionNameCreatorOptions): string {
-    const { stateName, argumentsNames, methodName, argumentRegistry }: ActionNameCreatorOptions = options;
+    const { statePath, argumentsNames, methodName, argumentRegistry }: ActionNameCreatorOptions = options;
 
     let argsList: string = '';
     for (let index: number = 0; index < argumentsNames.length; index++) {
@@ -25,5 +25,5 @@ export function actionNameCreator(options: ActionNameCreatorOptions): string {
         }
     }
 
-    return `@${stateName}.${methodName}(${argsList})`;
+    return `@${statePath.split('.').join('/')}.${methodName}(${argsList})`;
 }


### PR DESCRIPTION
This way we can better identify children reducer actions via type