### PR TITLE
feat: extensible NgxsDataEntityCollectionsRepository v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # To become 3.0.0
 
+-   Feature: make `NgxsDataEntityCollectionsRepository<V, K, C>` extensible
 -   Feature: support sort entities
 -   Feature: add `ngxsTestingPlatform` as tools for better testing
 -   Feature: add `ngxsDataDoCheck`, `ngxsDataAfterReset` lifecycle hooks

--- a/docs/pages/state-repository.md
+++ b/docs/pages/state-repository.md
@@ -177,3 +177,60 @@ class AppComponent implements OnInit {
     }
 }
 ```
+
+### Extending NgxsDataEntityCollectionsRepository
+
+If you need more than the default reducer for your entity collection (e.g. to enable loading states), then you can extend it like this:
+
+```
+interface CourseOptions {
+    loading: boolean;
+};
+
+@StateRepository()
+@State({
+    name: 'courses',
+    defaults: {
+      ...createEntityCollections(),
+      loading: false
+    }
+})
+@Injectable()
+export class CoursesEntitiesState extends NgxsDataEntityCollectionsRepository<Course, EntityIdType, CourseOptions> {
+
+    @Computed()
+    public get loading(): boolean {
+        return this.snapshot.loading;
+    }
+
+    @DataAction()
+    public setLoading(@Payload('loading') loading: boolean): void {
+        const state = this.getState();
+        this.setEntitiesState({
+            ...state,
+            loading,
+        });
+    }
+
+}
+```
+```
+@Component({
+    selector: 'app'
+    // ..
+})
+export class AppComponent implements OnInit {
+    constructor(private courses: CoursesEntitiesState, private api: ApiCoursesService) {}
+
+    public ngOnInit(): void {
+        this.courses.setLoading(true);
+        this.api.getCourses()
+          .pipe(
+              finalize(() => this.courses.setLoading(false)),
+          )
+          .subscribe((courses: Course[]) => {
+              this.courses.setAll(courses);
+          });
+    }
+}
+```

--- a/docs/pages/state-repository.md
+++ b/docs/pages/state-repository.md
@@ -180,9 +180,9 @@ class AppComponent implements OnInit {
 
 ### Extending NgxsDataEntityCollectionsRepository
 
-If you need more than the default reducer for your entity collection (e.g. to enable loading states), then you can extend it like this:
+If you need more than the default reducer properties for your entity collection (e.g. to track loading state), then you can extend it like this:
 
-```
+```ts
 interface CourseOptions {
     loading: boolean;
 };
@@ -214,7 +214,7 @@ export class CoursesEntitiesState extends NgxsDataEntityCollectionsRepository<Co
 
 }
 ```
-```
+```ts
 @Component({
     selector: 'app'
     // ..

--- a/lib/typings/src/entity/entity-context.ts
+++ b/lib/typings/src/entity/entity-context.ts
@@ -4,12 +4,12 @@ import { Observable } from 'rxjs';
 import { EntityPatchValue, EntityStateValue } from './entity-types';
 import { NgxsEntityCollections } from './ngxs-entity-collections';
 
-export interface EntityContext<V, K extends string | number> {
-    getState(): NgxsEntityCollections<V, K>;
+export interface EntityContext<V, K extends string | number, C = {}> {
+    getState(): NgxsEntityCollections<V, K, C>;
 
-    setState(val: EntityStateValue<NgxsEntityCollections<V, K>>): void;
+    setState(val: EntityStateValue<NgxsEntityCollections<V, K, C>>): void;
 
-    patchState(val: EntityPatchValue<NgxsEntityCollections<V, K>>): void;
+    patchState(val: EntityPatchValue<NgxsEntityCollections<V, K, C>>): void;
 
     dispatch(actions: ActionType | ActionType[]): Observable<void>;
 }

--- a/lib/typings/src/entity/entity-repository.ts
+++ b/lib/typings/src/entity/entity-repository.ts
@@ -4,14 +4,14 @@ import { Observable } from 'rxjs';
 import { EntityUpdate } from './entity-update';
 import { NgxsEntityCollections } from './ngxs-entity-collections';
 
-export interface EntityRepository<V, K extends string | number> {
+export interface EntityRepository<V, K extends string | number, C = {}> {
     name: string;
-    initialState: NgxsEntityCollections<V, K>;
-    state$: Observable<NgxsEntityCollections<V, K>>;
-    readonly snapshot: NgxsEntityCollections<V, K>;
+    initialState: NgxsEntityCollections<V, K, C>;
+    state$: Observable<NgxsEntityCollections<V, K, C>>;
+    readonly snapshot: NgxsEntityCollections<V, K, C>;
     primaryKey: string;
 
-    getState(): NgxsEntityCollections<V, K>;
+    getState(): NgxsEntityCollections<V, K, C>;
 
     dispatch(actions: ActionType | ActionType[]): Observable<void>;
 

--- a/lib/typings/src/entity/ngxs-entity-collections.ts
+++ b/lib/typings/src/entity/ngxs-entity-collections.ts
@@ -1,6 +1,6 @@
 import { EntityDictionary, EntityIdType } from './entity-types';
 
-export interface NgxsEntityCollections<V, K extends number | string = EntityIdType> {
+export type NgxsEntityCollections<V, K extends number | string = EntityIdType, C = {}> = {
     ids: K[];
     entities: EntityDictionary<K, V>;
-}
+} & C;


### PR DESCRIPTION
This allows extending NgxsDataEntityCollectionsRepository with a custom
state and custom actions. See integration/tests/entity/entity.spec.ts
for an example.

v1: PR for v1 was canceled.
v2: This follows suggestion by @splincode.